### PR TITLE
Backport BufferManager destructor fix

### DIFF
--- a/Svc/BufferManager/BufferManagerComponentImpl.cpp
+++ b/Svc/BufferManager/BufferManagerComponentImpl.cpp
@@ -53,7 +53,9 @@ namespace Svc {
   BufferManagerComponentImpl ::
     ~BufferManagerComponentImpl(void)
   {
-      this->cleanup();
+      if (m_setup) {
+          this->cleanup();
+      }
   }
 
   void BufferManagerComponentImpl ::


### PR DESCRIPTION
Backports an upstream fix https://github.com/nasa/fprime/pull/1383. Required for SSim when using `--help`, `--version` etc.